### PR TITLE
remove erroneous import in informatics __init__.py

### DIFF
--- a/ccsfp/informatics/__init__.py
+++ b/ccsfp/informatics/__init__.py
@@ -7,5 +7,4 @@ from ccsfp.informatics import molecules_and_images
 from ccsfp.informatics import carbon_capture
 from ccsfp.informatics import chemical_space_map
 from ccsfp.informatics import generation
-from ccsfp.informatics import pubchem_lookup
 from ccsfp.utilities import utility_functions


### PR DESCRIPTION
This will fix the install by the setup.py file by removing the erroneous import.